### PR TITLE
Use vendored OpenSSL for git2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.15.0+1.1.1k"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a5f6ae2ac04393b217ea9f700cd04fa9bf3d93fae2872069f3d15d908af70a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +436,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ chrono = "0.4"
 anyhow = "1.0"
 once_cell = "1.7"
 clap = { version = "3.0.0-beta.2", features = ["wrap_help"] }
-git2 = "0.13"
+git2 = { version = "0.13", features = ["vendored-openssl"] }
 similar = { version ="1.3", features = ["bytes", "inline"] }
 crossterm = "0.19"
 tui = { version = "0.14", default-features = false, features = ["crossterm"] }


### PR DESCRIPTION
Fix #8.