### PR TITLE
slight update to build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+checksum = "fcd70aa5597dbc42f7217a543f9ef2768b2ef823ba29036072d30e1d88e98406"
 dependencies = [
  "atty",
  "bitflags",
@@ -90,15 +90,14 @@ dependencies = [
  "termcolor",
  "terminal_size",
  "textwrap",
- "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+checksum = "0b5bb0d655624a0b8770d1c178fb8ffcb1f91cc722cb08f451e3dc72465421ac"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -419,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "2.4.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
 
 [[package]]
 name = "parking_lot"
@@ -600,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
  "terminal_size",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ itertools = "0.10"
 chrono = "0.4"
 anyhow = "1.0"
 once_cell = "1.8"
-clap = { version = "3.0.0-beta.2", features = ["wrap_help"] }
+clap = { version = "3.0.0-beta.4", features = ["wrap_help"] }
 git2 = { version = "0.13", features = ["vendored-openssl"] }
 similar = { version ="1.3", features = ["bytes", "inline"] }
 crossterm = "0.20"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use clap::{App, Arg};
 
 #[derive(Debug)]
@@ -20,7 +19,7 @@ pub enum UserType {
 }
 
 impl Args {
-    pub fn load() -> Result<Args> {
+    pub fn load() -> Args {
         let matches = App::new(env!("CARGO_PKG_NAME"))
             .version(env!("CARGO_PKG_VERSION"))
             .about(env!("CARGO_PKG_DESCRIPTION"))
@@ -111,7 +110,7 @@ impl Args {
             .unwrap_or_else(|e| e.exit());
         let tab_spaces = " ".repeat(tab_size);
 
-        Ok(Args {
+        Args {
             file_path,
             should_use_full_commit_hash,
             beyond_last_line,
@@ -120,6 +119,6 @@ impl Args {
             user_for_date,
             date_format,
             tab_spaces,
-        })
+        }
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -106,7 +106,9 @@ impl Args {
         };
         let date_format = String::from(matches.value_of("date-format").unwrap());
 
-        let tab_size = matches.value_of_t::<usize>("tab-size").ok().unwrap();
+        let tab_size = matches
+            .value_of_t::<usize>("tab-size")
+            .unwrap_or_else(|e| e.exit());
         let tab_spaces = " ".repeat(tab_size);
 
         Ok(Args {

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{App, Arg, ArgSettings};
+use clap::{App, Arg};
 
 #[derive(Debug)]
 pub struct Args {
@@ -73,7 +73,6 @@ impl Args {
                     .long("date-format")
                     .value_name("format")
                     .default_value("[%Y-%m-%d]")
-                    .setting(ArgSettings::AllowEmptyValues)
                     .about("Set date format: ref. https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html"),
             )
             .arg(
@@ -107,7 +106,7 @@ impl Args {
         };
         let date_format = String::from(matches.value_of("date-format").unwrap());
 
-        let tab_size = matches.value_of_t::<usize>("tab-size")?;
+        let tab_size = matches.value_of_t::<usize>("tab-size").ok().unwrap();
         let tab_spaces = " ".repeat(tab_size);
 
         Ok(Args {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use git_hist::{app, args::Args};
 
 fn main() -> Result<()> {
-    let args = Args::load()?;
+    let args = Args::load();
     app::run(args)?;
 
     Ok(())


### PR DESCRIPTION
v1.0.3 cannot build with my rust `1.54.0` with 2 errors.
This PR resolves them.

```bash
$ rustc -V
rustc 1.54.0 (a178d0322 2021-07-26)

$ cargo install git-hist --version 1.0.3

[..]

error[E0599]: no variant or associated item named `AllowEmptyValues` found for enum `ArgSettings` in the current scope
  --> /home/kazuhiro_hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/git-hist-1.0.3/src/args.rs:76:43
   |
76 |                     .setting(ArgSettings::AllowEmptyValues)
   |                                           ^^^^^^^^^^^^^^^^
   |                                           |
   |                                           variant or associated item not found in `ArgSettings`
   |                                           help: there is a variant with a similar name: `AllowHyphenValues`

[..]

error[E0277]: `(dyn std::error::Error + 'static)` cannot be shared between threads safely
   --> /home/kazuhiro_hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/git-hist-1.0.3/src/args.rs:110:63
    |
110 |         let tab_size = matches.value_of_t::<usize>("tab-size")?;
    |                                                               ^ `(dyn std::error::Error + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn std::error::Error + 'static)`
    = note: required because of the requirements on the impl of `Sync` for `std::ptr::Unique<(dyn std::error::Error + 'static)>`
    = note: required because it appears within the type `Box<(dyn std::error::Error + 'static)>`
    = note: required because it appears within the type `Option<Box<(dyn std::error::Error + 'static)>>`
    = note: required because it appears within the type `clap::Error`
    = note: required because of the requirements on the impl of `From<clap::Error>` for `anyhow::Error`
    = note: required because of the requirements on the impl of `FromResidual<Result<Infallible, clap::Error>>` for `Result<args::Args, anyhow::Error>`
    = note: required by `from_residual`

```